### PR TITLE
added BoardReserMCU to the HW Rev D

### DIFF
--- a/src/lora/boards/ISP4520D-EU/board.c
+++ b/src/lora/boards/ISP4520D-EU/board.c
@@ -63,6 +63,14 @@ void lora_hardware_uninit (void)
     SX126xIoDeInit();
 }
 
+void BoardResetMcu(void)
+{
+    CRITICAL_SECTION_BEGIN();
+
+    //Restart system
+    NVIC_SystemReset();
+}
+
 uint32_t BoardGetRandomSeed (void)
 {
     return ((*(uint32_t*)ID1) ^ (*(uint32_t*)ID2));


### PR DESCRIPTION
The scope of this change is the compatibility of the HW rev D to the newest version of the stack.

There are no known limitations.

The Code works fine with the EU End Device Example and an Development Kit with HW rev D. Only other change was that the ISP4520D-EU instead of the ISP4520E-EU folder was included.